### PR TITLE
Enhance session support

### DIFF
--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -71,8 +71,8 @@ function OpenIDConnectStrategy(
   this.name = url.parse(client.issuer.issuer).hostname;
 }
 
-OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, options) {
-  (async () => {
+OpenIDConnectStrategy.prototype.authenticate = async function authenticate(req, options) {
+  try {
     const client = this._client;
     if (!req.session) {
       throw new TypeError('authentication requires session support');
@@ -101,7 +101,6 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
 
         const sessionInfo = await session.get(sessionKey);
         sessionInfo.code_verifier = verifier;
-        
         await session.set(sessionKey, sessionInfo);
 
         switch (this._usePKCE) {
@@ -183,7 +182,7 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
 
     this._verify(...args);
     /* end authentication response */
-  })().catch((error) => {
+  } catch(error) {
     if (
       (error instanceof OPError &&
         error.error !== 'server_error' &&
@@ -194,7 +193,7 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
     } else {
       this.error(error);
     }
-  });
+  };
 };
 
 module.exports = OpenIDConnectStrategy;

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -7,6 +7,7 @@ const { BaseClient } = require('./client');
 const { random, codeChallenge } = require('./helpers/generators');
 const pick = require('./helpers/pick');
 const { resolveResponseType, resolveRedirectUri } = require('./helpers/client');
+const Session = require('./session');
 
 function verified(err, user, info = {}) {
   if (err) {
@@ -78,6 +79,7 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
     }
     const reqParams = client.callbackParams(req);
     const sessionKey = this._key;
+    const session = Session.wrap(req.session);
 
     /* start authentication request */
     if (Object.keys(reqParams).length === 0) {
@@ -92,11 +94,15 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
         params.nonce = random();
       }
 
-      req.session[sessionKey] = pick(params, 'nonce', 'state', 'max_age', 'response_type');
+      await session.set(sessionKey, pick(params, 'nonce', 'state', 'max_age', 'response_type'));
 
       if (this._usePKCE && params.response_type.includes('code')) {
         const verifier = random();
-        req.session[sessionKey].code_verifier = verifier;
+
+        const sessionInfo = await session.get(sessionKey);
+        sessionInfo.code_verifier = verifier;
+        
+        await session.set(sessionKey, sessionInfo);
 
         switch (this._usePKCE) {
           case 'S256':
@@ -116,13 +122,13 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
 
     /* start authentication response */
 
-    const session = req.session[sessionKey];
-    if (Object.keys(session || {}).length === 0) {
+    const sessionInfos = await session.get(sessionKey);
+    if (Object.keys(sessionInfos || {}).length === 0) {
       throw new Error(
         format(
           'did not find expected authorization request details in session, req.session["%s"] is %j',
           sessionKey,
-          session,
+          sessionInfos,
         ),
       );
     }
@@ -133,10 +139,10 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
       max_age: maxAge,
       code_verifier: codeVerifier,
       response_type: responseType,
-    } = session;
+    } = sessionInfos;
 
     try {
-      delete req.session[sessionKey];
+      await session.delete(sessionKey);
     } catch (err) {}
 
     const opts = {

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,0 +1,35 @@
+class Session {
+  async get(key) {}
+  async set(key, value) {}
+  async delete(key) {}
+}
+
+class SessionWrapper extends Session {
+  constructor (session) {
+    this.session = session;
+  }
+
+  async get(key) {
+    return this.session[key];
+  }
+
+  async set(key, value) {
+    this.session[key] = value;
+  }
+
+  async delete(key) {
+    delete this.session[key];
+  }
+}
+
+function wrap(session) {
+  if (session instanceof Session) {
+    return session;
+  }
+  return new SessionWrapper(session);
+}
+
+module.exports = {
+  Session,
+  wrap
+};

--- a/lib/session.js
+++ b/lib/session.js
@@ -6,6 +6,7 @@ class Session {
 
 class SessionWrapper extends Session {
   constructor (session) {
+    super();
     this.session = session;
   }
 

--- a/test/passport/passport_strategy.test.js
+++ b/test/passport/passport_strategy.test.js
@@ -53,7 +53,7 @@ describe('OpenIDConnectStrategy', () => {
     );
   });
 
-  it('checks for session presence', function (next) {
+  it('checks for session presence', async function (next) {
     const strategy = new Strategy({ client: this.client }, () => {});
 
     const req = new MockRequest('GET', '/login/oidc');
@@ -67,7 +67,7 @@ describe('OpenIDConnectStrategy', () => {
         next(err);
       }
     };
-    strategy.authenticate(req);
+    await strategy.authenticate(req);
   });
 
   describe('authenticate', function () {
@@ -92,7 +92,7 @@ describe('OpenIDConnectStrategy', () => {
 
       this.client.callback = sinon.spy();
 
-      strategy.authenticate(req, {});
+      await strategy.authenticate(req, {});
       sinon.assert.calledOnce(this.client.callback);
       sinon.assert.calledWith(
         this.client.callback,
@@ -105,7 +105,7 @@ describe('OpenIDConnectStrategy', () => {
   });
 
   describe('initate', function () {
-    it('starts authentication requests for GETs', function () {
+    it('starts authentication requests for GETs', async function () {
       const params = { foo: 'bar' };
       const strategy = new Strategy({ client: this.client, params }, () => {});
 
@@ -113,7 +113,7 @@ describe('OpenIDConnectStrategy', () => {
       req.session = {};
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
 
       expect(params).to.eql({ foo: 'bar' });
       expect(strategy.redirect.calledOnce).to.be.true;
@@ -128,7 +128,7 @@ describe('OpenIDConnectStrategy', () => {
       );
     });
 
-    it('starts authentication requests for POSTs', function () {
+    it('starts authentication requests for POSTs', async function () {
       const strategy = new Strategy({ client: this.client }, () => {});
 
       const req = new MockRequest('POST', '/login/oidc');
@@ -136,7 +136,7 @@ describe('OpenIDConnectStrategy', () => {
       req.body = {};
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
 
       expect(strategy.redirect.calledOnce).to.be.true;
       const target = strategy.redirect.firstCall.args[0];
@@ -150,7 +150,7 @@ describe('OpenIDConnectStrategy', () => {
       );
     });
 
-    it('can have redirect_uri and scope specified', function () {
+    it('can have redirect_uri and scope specified', async function () {
       const strategy = new Strategy(
         {
           client: this.client,
@@ -166,7 +166,7 @@ describe('OpenIDConnectStrategy', () => {
       req.session = {};
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
 
       expect(strategy.redirect.calledOnce).to.be.true;
       const target = strategy.redirect.firstCall.args[0];
@@ -174,7 +174,7 @@ describe('OpenIDConnectStrategy', () => {
       expect(target).to.include('scope=openid%20profile');
     });
 
-    it('can have authorization parameters specified at runtime', function () {
+    it('can have authorization parameters specified at runtime', async function () {
       const strategy = new Strategy(
         {
           client: this.client,
@@ -190,14 +190,14 @@ describe('OpenIDConnectStrategy', () => {
       req.session = {};
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req, { resource: 'urn:example:foo' });
+      await strategy.authenticate(req, { resource: 'urn:example:foo' });
 
       expect(strategy.redirect.calledOnce).to.be.true;
       const target = strategy.redirect.firstCall.args[0];
       expect(target).to.include(`resource=${encodeURIComponent('urn:example:foo')}`);
     });
 
-    it('automatically includes nonce for where it applies', function () {
+    it('automatically includes nonce for where it applies', async function () {
       const strategy = new Strategy(
         {
           client: this.client,
@@ -213,7 +213,7 @@ describe('OpenIDConnectStrategy', () => {
       req.session = {};
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
 
       expect(strategy.redirect.calledOnce).to.be.true;
       const target = strategy.redirect.firstCall.args[0];
@@ -243,7 +243,7 @@ describe('OpenIDConnectStrategy', () => {
         }).to.throw('foobar is not valid/implemented PKCE code_challenge_method');
       });
 
-      it('can be set to use PKCE (S256)', function () {
+      it('can be set to use PKCE (S256)', async function () {
         const strategy = new Strategy(
           {
             client: this.client,
@@ -256,7 +256,7 @@ describe('OpenIDConnectStrategy', () => {
         req.session = {};
 
         strategy.redirect = sinon.spy();
-        strategy.authenticate(req);
+        await strategy.authenticate(req);
 
         expect(strategy.redirect.calledOnce).to.be.true;
         const target = strategy.redirect.firstCall.args[0];
@@ -266,7 +266,7 @@ describe('OpenIDConnectStrategy', () => {
         expect(req.session['oidc:op.example.com']).to.have.property('code_verifier');
       });
 
-      it('can be set to use PKCE (plain)', function () {
+      it('can be set to use PKCE (plain)', async function () {
         const strategy = new Strategy(
           {
             client: this.client,
@@ -279,7 +279,7 @@ describe('OpenIDConnectStrategy', () => {
         req.session = {};
 
         strategy.redirect = sinon.spy();
-        strategy.authenticate(req);
+        await strategy.authenticate(req);
 
         expect(strategy.redirect.calledOnce).to.be.true;
         const target = strategy.redirect.firstCall.args[0];
@@ -290,7 +290,7 @@ describe('OpenIDConnectStrategy', () => {
       });
     });
 
-    it('can have session key specifed', function () {
+    it('can have session key specifed', async function () {
       const strategy = new Strategy(
         {
           client: this.client,
@@ -303,7 +303,7 @@ describe('OpenIDConnectStrategy', () => {
       req.session = {};
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
 
       expect(req.session).to.have.property('oidc:op.example.com:foo');
       expect(req.session['oidc:op.example.com:foo']).to.have.keys(
@@ -314,8 +314,8 @@ describe('OpenIDConnectStrategy', () => {
     });
   });
 
-  describe('callback', function () {
-    it('triggers the verify function and then the success one', function (next) {
+  describe('callback', async function () {
+    it('triggers the verify function and then the success one', async function () {
       const ts = { foo: 'bar' };
       sinon.stub(this.client, 'callback').callsFake(async () => ts);
 
@@ -324,8 +324,11 @@ describe('OpenIDConnectStrategy', () => {
         done(null, tokenset);
       });
 
+      let resolve;
+      const promise = new Promise(res => { resolve = res; });
+
       strategy.success = () => {
-        next();
+        resolve();
       };
 
       const req = new MockRequest('GET', '/login/oidc/callback?code=foobar&state=state');
@@ -337,10 +340,12 @@ describe('OpenIDConnectStrategy', () => {
         },
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      
+      return promise;
     });
 
-    it('triggers the error function when server_error is encountered', function (next) {
+    it('triggers the error function when server_error is encountered', async function () {
       const strategy = new Strategy({ client: this.client }, () => {});
 
       const req = new MockRequest('GET', '/login/oidc/callback?error=server_error&state=state');
@@ -352,39 +357,53 @@ describe('OpenIDConnectStrategy', () => {
         },
       };
 
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
       strategy.error = (error) => {
         try {
           expect(error.error).to.equal('server_error');
-          next();
+          resolve();
         } catch (err) {
-          next(err);
+          reject(err);
         }
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      return promise;
     });
 
-    it('lets the dev know when most common problems with session occur', function (next) {
+    it('lets the dev know when most common problems with session occur', async function () {
       const strategy = new Strategy({ client: this.client }, () => {});
 
       const req = new MockRequest('GET', '/login/oidc/callback?code=code&state=foo');
       req.session = {};
+
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
 
       strategy.error = (error) => {
         try {
           expect(error.message).to.eql(
             'did not find expected authorization request details in session, req.session["oidc:op.example.com"] is undefined',
           );
-          next();
+          resolve();
         } catch (err) {
-          next(err);
+          reject(err);
         }
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      return promise;
     });
 
-    it('triggers the error function when non oidc error is encountered', function (next) {
+    it('triggers the error function when non oidc error is encountered', async function () {
       const strategy = new Strategy({ client: this.client }, () => {});
 
       sinon.stub(this.client, 'callback').callsFake(async () => {
@@ -400,19 +419,26 @@ describe('OpenIDConnectStrategy', () => {
         },
       };
 
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
       strategy.error = (error) => {
         try {
           expect(error.message).to.equal('callback error');
-          next();
+          resolve();
         } catch (err) {
-          next(err);
+          reject(err);
         }
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      return promise;
     });
 
-    it('triggers the fail function when oidc error is encountered', function (next) {
+    it('triggers the fail function when oidc error is encountered', async function () {
       const strategy = new Strategy({ client: this.client }, () => {});
 
       const req = new MockRequest('GET', '/login/oidc/callback?error=login_required&state=state');
@@ -424,19 +450,26 @@ describe('OpenIDConnectStrategy', () => {
         },
       };
 
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
       strategy.fail = (error) => {
         try {
           expect(error.error).to.equal('login_required');
-          next();
+          resolve();
         } catch (err) {
-          next(err);
+          reject(err);
         }
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      return promise;
     });
 
-    it('triggers the error function for errors during verify', function (next) {
+    it('triggers the error function for errors during verify', async function () {
       const strategy = new Strategy({ client: this.client }, (tokenset, done) => {
         done(new Error('user find error'));
       });
@@ -453,19 +486,26 @@ describe('OpenIDConnectStrategy', () => {
         },
       };
 
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
       strategy.error = (error) => {
         try {
           expect(error.message).to.equal('user find error');
-          next();
+          resolve();
         } catch (err) {
-          next(err);
+          reject(err);
         }
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      return promise;
     });
 
-    it('triggers the fail function when verify yields no account', function (next) {
+    it('triggers the fail function when verify yields no account', async function () {
       const strategy = new Strategy({ client: this.client }, (tokenset, done) => {
         done();
       });
@@ -482,21 +522,33 @@ describe('OpenIDConnectStrategy', () => {
         },
       };
 
+      let resolve;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+      });
+
       strategy.fail = () => {
-        next();
+        resolve();
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      return promise;
     });
 
-    it('does userinfo request too if part of verify arity and resulting tokenset', function (next) {
+    it('does userinfo request too if part of verify arity and resulting tokenset', async function () {
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
       const strategy = new Strategy({ client: this.client }, (tokenset, userinfo, done) => {
         try {
           expect(tokenset).to.be.ok;
           expect(userinfo).to.be.ok;
           done(null, { sub: 'foobar' });
         } catch (err) {
-          next(err);
+          reject(err);
         }
       });
 
@@ -515,13 +567,14 @@ describe('OpenIDConnectStrategy', () => {
       };
 
       strategy.success = () => {
-        next();
+        resolve();
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      return promise;
     });
 
-    it('throws when userinfo is requested but no access_token was returned', function (next) {
+    it('throws when userinfo is requested but no access_token was returned', async function () {
       const strategy = new Strategy({ client: this.client }, (tokenset, userinfo, done) => {});
 
       const ts = { id_token: 'foo' };
@@ -536,6 +589,12 @@ describe('OpenIDConnectStrategy', () => {
         },
       };
 
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
       strategy.fail = (err) => {
         try {
           expect(err.name).to.equal('RPError');
@@ -543,16 +602,23 @@ describe('OpenIDConnectStrategy', () => {
             'expected access_token to be returned when asking for userinfo in verify callback',
           );
           expect(err).to.have.property('tokenset');
-          next();
+          resolve();
         } catch (e) {
-          next(e);
+          reject(e);
         }
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      return promise;
     });
 
-    it('receives a request as the first parameter if passReqToCallback is set', function (next) {
+    it('receives a request as the first parameter if passReqToCallback is set', async function () {
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
       const strategy = new Strategy(
         {
           client: this.client,
@@ -564,7 +630,7 @@ describe('OpenIDConnectStrategy', () => {
             expect(tokenset).to.be.ok;
             done(null, { sub: 'foobar' });
           } catch (err) {
-            next(err);
+            reject(err);
           }
         },
       );
@@ -582,13 +648,20 @@ describe('OpenIDConnectStrategy', () => {
       };
 
       strategy.success = () => {
-        next();
+        resolve();
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      return promise;
     });
 
-    it('receives a request and userinfo with passReqToCallback: true and userinfo', function (next) {
+    it('receives a request and userinfo with passReqToCallback: true and userinfo', async function () {
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
       const strategy = new Strategy(
         {
           client: this.client,
@@ -601,7 +674,7 @@ describe('OpenIDConnectStrategy', () => {
             expect(userinfo).to.be.ok;
             done(null, { sub: 'foobar' });
           } catch (err) {
-            next(err);
+            reject(err);
           }
         },
       );
@@ -621,10 +694,11 @@ describe('OpenIDConnectStrategy', () => {
       };
 
       strategy.success = () => {
-        next();
+        resolve();
       };
 
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
+      return promise;
     });
   });
 });


### PR DESCRIPTION
## What does this PR do ?

This PR changes the way session are used, by providing a Session interface that implement the following async methods `get`, `set`, `delete`.

During authentication if the provided `req.session` is not an instance of `Session` then the given object is wrapped using a `SessionWrapper` that extends the `Session` class.

Doing this changes allow the `openid-client` package to be used without Express only, because now other packages can provide their own Session system without breaking the package as long as they implement the `Session` class
